### PR TITLE
guardar foto

### DIFF
--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -48,14 +48,13 @@ class IncidentesController extends \BaseController {
 		$incidente -> idIncidente = null;
 		$incidente -> fecha = Input::get('fecha');
 		$incidente -> idEspecie = Input::get('idEspecie');
-		$incidente -> rutaFoto = 'oli.jpg';
 		$incidente -> long = Input::get('long');
 		$incidente -> lat = Input::get('lat');
 		$incidente -> mpioOrigen = Input::get('mpioOrigen');
 		$incidente -> mpioDestino = Input::get('mpioDestino');
 		$incidente -> km = Input::get('km');
-
-		$resultado = $this->servicioOMMFCM->crearIncidente($incidente);
+		$imagen64  = Input::get('imagen');
+		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64);
 
 		if ($resultado)
 		{

--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -54,7 +54,8 @@ class IncidentesController extends \BaseController {
 		$incidente -> mpioDestino = Input::get('mpioDestino');
 		$incidente -> km = Input::get('km');
 		$imagen64  = Input::get('imagen');
-		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64);
+		$extensionImg = Input::get('extension');
+		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64, $extensionImg);
 
 		if ($resultado)
 		{

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -2,9 +2,11 @@
 	namespace services;
 	use Incidente;
 	use Request;
+	use Image;
+	use File;
 
 	class ServicioOMMFCM implements ServicioOMMFCMInterface{
-		// TODO eliminar esto cuando tegamos paginacion
+		
 		public function getIncidentes()
 		{
 	   		$pagina = Request::get('pagina');
@@ -15,10 +17,15 @@
 	   		return $incidentes;
 	   	}
 
-	    public function crearIncidente($incidente)
+	    public function crearIncidente($incidente, $imagen64)
 	    {
+			$imagen = base64_decode($imagen64);
+			$ruta_imagen 	= public_path() . "/imagenes/incidentes/" . "incidente_" . time() . ".png";
+			File::put($ruta_imagen, $imagen);
+
 			$nuevoIncidente = new Incidente;
 			$nuevoIncidente = $incidente;
+			$nuevoIncidente -> rutaFoto = $ruta_imagen;
 			$resultado = $nuevoIncidente -> save(); 
 
 			return $resultado;

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -17,10 +17,10 @@
 	   		return $incidentes;
 	   	}
 
-	    public function crearIncidente($incidente, $imagen64)
+	    public function crearIncidente($incidente, $imagen64, $extensionImg)
 	    {
 			$imagen = base64_decode($imagen64);
-			$ruta_imagen 	= public_path() . "/imagenes/incidentes/" . "incidente_" . time() . ".png";
+			$ruta_imagen 	= public_path() . "/imagenes/incidentes/" . "incidente_" . time() . $extensionImg;
 			File::put($ruta_imagen, $imagen);
 
 			$nuevoIncidente = new Incidente;

--- a/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
@@ -2,8 +2,8 @@
 	namespace services;
 
 	interface ServicioOMMFCMInterface {  
-	    public function getIncidentes(); // TODO eliminar esto cuando tegamos paginacion
-	    public function crearIncidente($incidente);
+	    public function getIncidentes(); 
+	    public function crearIncidente($incidente, $imagen64);
 	    public function eliminarIncidente($id);
 	    public function modificarIncidente($incidente);
 	}

--- a/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
@@ -3,7 +3,7 @@
 
 	interface ServicioOMMFCMInterface {  
 	    public function getIncidentes(); 
-	    public function crearIncidente($incidente, $imagen64);
+	    public function crearIncidente($incidente, $imagen64, $extensionImg);
 	    public function eliminarIncidente($id);
 	    public function modificarIncidente($incidente);
 	}


### PR DESCRIPTION
Se agregó la funcionalidad de guardar foto al momento de crear el
incidente. Se debe enviar la foto al servicio en base64. Se puede
utilizar la página https://www.base64-image.de/ para probar el servicio
(meter el string base64 en el json del post)
