### PR TITLE
Incidentes: manejo de errores

### DIFF
--- a/Api/OMMFCM/.gitignore
+++ b/Api/OMMFCM/.gitignore
@@ -1,5 +1,6 @@
 /bootstrap/compiled.php
 /vendor
+/public/imagenes/incidentes
 composer.phar
 composer.lock
 .env.*.php

--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -58,19 +58,19 @@ class IncidentesController extends \BaseController
 		$extensionImg = Input::get('extension');
 		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64, $extensionImg);
 
-		if ($resultado)
+		if ($resultado <= 400)
 		{
 			return Response::json(array(
 				'error' => false,
 				'incidente' => $incidente),
-				201
+				$resultado 
 			);
 		}
 		else
 		{
 			return Response::json(array(
 				'error' => true),
-				500
+				$resultado
 			);
 		}	
 	}

--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -58,7 +58,7 @@ class IncidentesController extends \BaseController
 		$extensionImg = Input::get('extension');
 		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64, $extensionImg);
 
-		if ($resultado <= 400)
+		if ($resultado < 400)
 		{
 			return Response::json(array(
 				'error' => false,

--- a/Api/OMMFCM/app/database/migrations/2015_09_20_011409_add_null_attributes.php
+++ b/Api/OMMFCM/app/database/migrations/2015_09_20_011409_add_null_attributes.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddNullAttributes extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		DB::statement('ALTER TABLE `incidentes` MODIFY `idEspecie` BIGINT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `fecha` TIMESTAMP NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `long` DECIMAL(11,8) NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `lat` DECIMAL(10,8) NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioOrigen` INT(11) NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioDestino` INT(11) NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `km` DECIMAL(8,2) NULL;');
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		DB::statement('ALTER TABLE `incidentes` MODIFY `idEspecie` BIGINT NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `fecha` NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `long` NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `lat` NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioOrigen` INT(11) NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioDestino` INT(11) NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `km` NOT NULL;');
+	}
+
+}

--- a/Api/OMMFCM/app/database/migrations/2015_09_20_022151_add_foreign_keys.php
+++ b/Api/OMMFCM/app/database/migrations/2015_09_20_022151_add_foreign_keys.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddForeignKeys extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		// Para añadir las llaves foráneas es necesario que las columnas a asociar tengan el mismo tipo de datos
+		DB::statement('ALTER TABLE `incidentes` MODIFY `idEspecie` BIGINT UNSIGNED NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioOrigen` INT(11) UNSIGNED NOT NULL;');
+		DB::statement('ALTER TABLE `incidentes` MODIFY `mpioDestino` INT(11) UNSIGNED NOT NULL;');
+		DB::statement('ALTER TABLE `municipios` MODIFY `id_municipio` INT(11) UNSIGNED NOT NULL;');
+	 
+		DB::statement('ALTER TABLE incidentes ADD FOREIGN KEY (idEspecie) REFERENCES especies(idEspecie)');
+		DB::statement('ALTER TABLE incidentes ADD FOREIGN KEY (mpioOrigen) REFERENCES municipios(id_municipio)');
+		DB::statement('ALTER TABLE incidentes ADD FOREIGN KEY (mpioDestino) REFERENCES municipios(id_municipio)');
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		DB::statement('ALTER TABLE `incidentes` DROP FOREIGN KEY fk_idEspecie');
+		DB::statement('ALTER TABLE `incidentes` DROP FOREIGN KEY fk_mpioOrigen');
+		DB::statement('ALTER TABLE `incidentes` DROP FOREIGN KEY fk_mpioDestino');
+	}
+
+}

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -21,9 +21,24 @@
 
 	    public function crearIncidente($incidente, $imagen64, $extensionImg)
 	    {
-	    	if(is_null($imagen64))
+	    	if(is_null($imagen64) || is_null($extensionImg))
 	    	{
-	    		return false; // TODO definir la respuesta del servidor ante campos vacíos y agregar validación
+	    		return 400;
+	    	}
+
+	    	if(is_null($incidente -> idEspecie))
+	    	{
+	    		$incidente -> idEspecie = 0;
+	    	}
+
+	    	if(is_null($incidente -> mpioOrigen))
+	    	{
+	    		$incidente -> mpioOrigen = 0;
+	    	}
+
+	    	if(is_null($incidente -> mpioDestino))
+	    	{
+	    		$incidente -> mpioDestino = 0;
 	    	}
 
 	    	$thumbnailAncho = 200;
@@ -35,49 +50,75 @@
 			$nombreImagen 	= "incidente_" . time();
 			$rutaThumbnail = $ruta . $nombreImagen . "_thumbnail" . $extensionImg;
 			$nombreImagen  = $nombreImagen . $extensionImg;
+
 			$resultado = File::put($ruta . $nombreImagen, $imagen);
 
 			if(!$resultado)
 			{
-				return $resultado;
+				return 500;
 			}
 
 			$resultado = $imagenThumbnail -> save($rutaThumbnail);
 
 			if(!$resultado)
 			{
-				return $resultado;
+				return 500;
 			}
  
 			$nuevoIncidente = new Incidente;
 			$nuevoIncidente = $incidente;
 			$nuevoIncidente -> rutaFoto = $ruta . $nombreImagen;
 			$nuevoIncidente -> rutaThumbnail = $rutaThumbnail;
+
 			$resultado = $nuevoIncidente -> save(); 
 
-			return $resultado;
+	    	if($resultado)
+	    	{
+				return 200;	    		
+	    	}
+
+	    	return 500;	    
 	    }
 
 	    public function eliminarIncidente($id)
 	    {
 	    	$incidente = Incidente::find($id);
+	    	$rutaImagen = $incidente -> rutaFoto;
+	    	$rutaThumbnail = $incidente -> rutaThumbnail;
+	    	$resultado = File::delete($rutaImagen, $rutaThumbnail);
+
+	    	if(!$resultado)
+	    	{
+	    		return 500;
+	    	}
+
 	    	$resultado = $incidente -> delete();
 
-			return $resultado;
+	    	if($resultado)
+	    	{
+				return 200;	    		
+	    	}
+
+	    	return 500;	    
 	    }
 
 	    public function modificarIncidente($incidente)
 	    {
 	    	$incidenteExistente = Incidente::find($incidente -> idIncidente);
 
-			if ($incidente -> idEspecie)
+			if(!$incidente -> idEspecie)
 			{
-				$incidenteExistente -> idEspecie = $incidente -> idEspecie;
+				return 400;	
 			}
 
+			$incidenteExistente -> idEspecie = $incidente -> idEspecie;
 			$resultado = $incidenteExistente -> save();
 
-			return $resultado;
+			if($resultado)
+			{
+				return 200;
+			}
+			return 500;
 	    }
 
 	    public function getEspecies()


### PR DESCRIPTION
Se agregaron códigos de errores a los métodos utilizados en el
controlador de incidentes.
Se añadieron las llaves foráneas (correr migraciones nuevas antes de
correr el proyecto)
Se modificaron los atributos de Incidentes (no todos) para que acepten
valores nulos.
