### PR TITLE
Crear modelo de EstadoEspecies

### DIFF
--- a/Api/OMMFCM/app/database/migrations/2015_10_13_023718_crearTablaEstadoEspecie.php
+++ b/Api/OMMFCM/app/database/migrations/2015_10_13_023718_crearTablaEstadoEspecie.php
@@ -15,7 +15,7 @@ class CrearTablaEstadoEspecie extends Migration {
 		// Crear tabla de estados de especies
 		Schema::create('estadosEspecies', function(Blueprint $table)
     	{
-	        $table->bigIncrements('idEstadoEspecie');
+			$table->tinyInteger('idEstadoEspecie')->unsigned()->autoIncrement();
 	        $table->string('estado');
 	        $table->timestamps();
     	});
@@ -23,11 +23,11 @@ class CrearTablaEstadoEspecie extends Migration {
 		// Agregar atributo de estado a las especies
 		Schema::table('especies', function($table)
 		{
-		    $table->bigInteger('idEstadoEspecie');		    
+		    $table->tinyInteger('idEstadoEspecie');		    
 		});
 
 		// Agregar el tipo unsigned a la columna  idEstadoEspecie en la tabla especies para poder crear luego la llave foranea (no se puede crear una FK con tipos diferentes)		
-		DB::statement('ALTER TABLE `especies` MODIFY `idEstadoEspecie` BIGINT UNSIGNED NULL;');
+		DB::statement('ALTER TABLE `especies` MODIFY `idEstadoEspecie` TINYINT UNSIGNED NULL;');
 
 		// Agregar llave foranea. 
 		DB::statement('ALTER TABLE especies ADD FOREIGN KEY (idEstadoEspecie) REFERENCES estadosEspecies(idEstadoEspecie)');		

--- a/Api/OMMFCM/app/database/migrations/2015_10_13_023718_crearTablaEstadoEspecie.php
+++ b/Api/OMMFCM/app/database/migrations/2015_10_13_023718_crearTablaEstadoEspecie.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CrearTablaEstadoEspecie extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		// Crear tabla de estados de especies
+		Schema::create('estadosEspecies', function(Blueprint $table)
+    	{
+	        $table->bigIncrements('idEstadoEspecie');
+	        $table->string('estado');
+	        $table->timestamps();
+    	});
+
+		// Agregar atributo de estado a las especies
+		Schema::table('especies', function($table)
+		{
+		    $table->bigInteger('idEstadoEspecie');		    
+		});
+
+		// Agregar el tipo unsigned a la columna  idEstadoEspecie en la tabla especies para poder crear luego la llave foranea (no se puede crear una FK con tipos diferentes)		
+		DB::statement('ALTER TABLE `especies` MODIFY `idEstadoEspecie` BIGINT UNSIGNED NULL;');
+
+		// Agregar llave foranea. 
+		DB::statement('ALTER TABLE especies ADD FOREIGN KEY (idEstadoEspecie) REFERENCES estadosEspecies(idEstadoEspecie)');		
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		// Eliminar llave foranea 
+		DB::statement('ALTER TABLE `especies` DROP FOREIGN KEY fk_idEstadoEspecie');		
+
+		// Eliminar columna de estado en especies
+		Schema::table('especies', function($table)
+		{
+		    $table->dropColumn('idEstadoEspecie');		    
+		});
+
+		// Eliminar tabla de estados de especies
+		Schema::drop('estadosEspecies');
+	}
+
+}

--- a/Api/OMMFCM/app/models/Especie.php
+++ b/Api/OMMFCM/app/models/Especie.php
@@ -4,7 +4,13 @@
 		protected $fillable = array('nombreComun', 'nombreCientifico');
 		protected $primaryKey = 'idEspecie';
 
-		public function incidentes(){
+		public function incidentes()
+		{
     		return $this -> hasMany('Incidente');
     	}
+
+		public function estadoEspecie()
+		{
+			return $this -> belongsTo('estadoEspecie');
+		}
 	}

--- a/Api/OMMFCM/app/models/EstadoEspecie.php
+++ b/Api/OMMFCM/app/models/EstadoEspecie.php
@@ -1,0 +1,13 @@
+<?php
+ 
+class EstadoEspecie extends Eloquent {
+ 
+    protected $table = 'estadosEspecies';
+    protected $primaryKey = 'idEstadoEspecie';
+	protected $fillable = array('estado');
+	
+	public function especies()
+	{
+		return $this -> hasMany('Especie');
+	}
+}


### PR DESCRIPTION
Se agregó la migración correspondiente a la nueva tabla estado especie,
tomando en cuenta la creación de un nuevo campo en la tabla especie que
apunta con una llave foránea a la tabla estadoespecie. Se agregó el
modelo correspondiente a estado especie.
