### PR TITLE
Eliminar municipios de incidentes

### DIFF
--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -58,12 +58,8 @@ class IncidentesController extends \BaseController
 		$incidente = new Incidente;
 		$incidente -> idIncidente = null;
 		$incidente -> fecha = Input::get('fecha');
-		$incidente -> idEspecie = Input::get('idEspecie');
 		$incidente -> long = Input::get('long');
 		$incidente -> lat = Input::get('lat');
-		$incidente -> mpioOrigen = Input::get('mpioOrigen');
-		$incidente -> mpioDestino = Input::get('mpioDestino');
-		$incidente -> km = Input::get('km');
 		$imagen64  = Input::get('imagen');
 		$extensionImg = Input::get('extension');
 		$resultado = $this->servicioOMMFCM->crearIncidente($incidente, $imagen64, $extensionImg);

--- a/Api/OMMFCM/app/database/migrations/2015_10_21_014030_delete_column_municipio.php
+++ b/Api/OMMFCM/app/database/migrations/2015_10_21_014030_delete_column_municipio.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DeleteColumnMunicipio extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		DB::statement('ALTER TABLE `incidentes` DROP FOREIGN KEY incidentes_ibfk_2');
+		DB::statement('ALTER TABLE `incidentes` DROP FOREIGN KEY incidentes_ibfk_3');
+		Schema::table('incidentes', function($table)
+		{
+		    $table->dropColumn('mpioOrigen'); 
+		    $table->dropColumn('mpioDestino');    
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('incidentes', function($table)
+		{
+		    $table->integer('mpioOrigen'); 
+		    $table->integer('mpioDestino');    
+		});
+	}
+
+}

--- a/Api/OMMFCM/app/models/Incidente.php
+++ b/Api/OMMFCM/app/models/Incidente.php
@@ -1,20 +1,10 @@
 <?php
 	class Incidente extends Eloquent{
 
-		protected $fillable = array('fecha', 'rutaFoto', 'rutaThumbnail', 'long', 'lat', 'mpioOrigen', 'mpioDestino', 'km', 'idEspecie', 'ruta');
+		protected $fillable = array('fecha', 'rutaFoto', 'rutaThumbnail', 'long', 'lat', 'km', 'idEspecie', 'ruta');
 		protected $primaryKey = 'idIncidente';
 
 		public function especie(){
 			return $this -> belongsTo('Especie');
-		}
-
-		public function mpioOrigen()
-		{
-			return $this -> hasOne('Municipio', 'id_municipio', 'mpioOrigen');
-		}
-
-		public function mpioDestino()
-		{
-			return $this -> hasOne('Municipio', 'id_municipio', 'mpioDestino');
 		}
 	}

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -33,20 +33,8 @@
 	    		return 400;
 	    	}
 
-	    	if(is_null($incidente -> idEspecie))
-	    	{
-	    		$incidente -> idEspecie = 0;
-	    	}
-
-	    	if(is_null($incidente -> mpioOrigen))
-	    	{
-	    		$incidente -> mpioOrigen = 0;
-	    	}
-
-	    	if(is_null($incidente -> mpioDestino))
-	    	{
-	    		$incidente -> mpioDestino = 0;
-	    	}
+	    	// Le asignamos la idEspecie 0 para definir que no se le ha asignado ninguna especie
+	    	$incidente -> idEspecie = 0;	    	
 
 	    	$thumbnailAncho = 200;
 	    	$thumbnailAlto = 200;


### PR DESCRIPTION
Se eliminó la columna de municipios en incidentes, se actualizó el
modelo y se eliminaron las entradas que ya no eran requeridas en el
método crear incidente
