### PR TITLE
Omitir especie default

### DIFF
--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -136,13 +136,13 @@
 	    public function getEspecies($pagina, $resultados)
 	    {
 	    	// Regresar todas las especies, excepto la que tiene id=0 (es la especie default)
-	   		$especies = Especie::where('idEspecie', '>', 0)->get();
+	   		$especies = Especie::all();
 
 	   		// Validar que los dos parámetros de paginación fueron enviados, de lo contrario mandar todas las especies
 	   		if(!is_null($pagina) && !is_null($resultados))
 	   		{
 				Especie::resolveConnection()->getPaginator()->setCurrentPage($pagina);
-		   		$especies = Especie::paginate($resultados);	   			
+		   		$especies = Especie::where('idEspecie', '>', 0)->paginate($resultados);	   			
 	   		}
 
 	   		return $especies;	    	

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -135,7 +135,8 @@
 
 	    public function getEspecies($pagina, $resultados)
 	    {
-	   		$especies = Especie::all();
+	    	// Regresar todas las especies, excepto la que tiene id=0 (es la especie default)
+	   		$especies = Especie::where('idEspecie', '>', 0)->get();
 
 	   		// Validar que los dos parámetros de paginación fueron enviados, de lo contrario mandar todas las especies
 	   		if(!is_null($pagina) && !is_null($resultados))


### PR DESCRIPTION
Se modificó el servicio para que omita la especie default cuando
regrese todas las especies
