### PR TITLE
Chsalgado/especies controller tests

### DIFF
--- a/Api/OMMFCM/app/controllers/EspeciesController.php
+++ b/Api/OMMFCM/app/controllers/EspeciesController.php
@@ -19,8 +19,8 @@ class EspeciesController extends \BaseController
 	{
 		$pagina = Request::get('pagina');
 	   	$resultados = Request::get('resultados');
-		$especies = $this->servicioOMMFCM->getEspecies($pagina, $resultados);
-
+	   	$especies = $this->servicioOMMFCM->getEspecies($pagina, $resultados);
+	
 		return Response::json(array(
 			'error' => false,
 			'especies' => $especies -> toArray()),

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -40,8 +40,6 @@
 	    	$thumbnailAncho = 200;
 	    	$thumbnailAlto = 200;
 			$imagen = base64_decode($imagen64);
-			$imagenThumbnail = ImageResize::createFromString(base64_decode($imagen64));
-			$imagenThumbnail -> resize($thumbnailAncho, $thumbnailAlto);
 			$ruta = public_path() . "/imagenes/incidentes/";
 			$nombreImagen 	= "incidente_" . time();
 			$rutaThumbnail = $ruta . $nombreImagen . "_thumbnail" . $extensionImg;
@@ -53,7 +51,9 @@
 			{
 				return 500;
 			}
-
+			
+			$imagenThumbnail = new ImageResize($ruta . $nombreImagen, $imagen);
+			$imagenThumbnail -> resize($thumbnailAncho, $thumbnailAlto);
 			$resultado = $imagenThumbnail -> save($rutaThumbnail);
 
 			if(!$resultado)

--- a/Api/OMMFCM/app/tests/EspeciesControllerTest.php
+++ b/Api/OMMFCM/app/tests/EspeciesControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+class EspeciesControllerTest extends TestCase {
+
+/*	public function setUp()
+	{
+	    parent::setUp();
+	 
+	    $this->mock('Services\ServicioOMMFCMInterface');
+	}
+	
+	public function tearDown()
+    {
+        Mockery::close();
+    } 
+	
+	public function mock($class)
+	{
+	    $mock = Mockery::mock($class);
+	 
+	    $this->app->instance($class, $mock);
+	 
+	    return $mock;
+	}
+	*/
+	/**
+	 * A basic functional test example.
+	 *
+	 * @return void
+	 */
+	public function testIndex()
+	{
+	   	// Generar especies que devuelve el servicio mock
+	   	$especiesEsperadas = new Especie();
+	   	$especiesEsperadas -> nombreComun = 'unNombreDePrueba';
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo getEspecies para que devuelva las especies esperadas
+	    $mock->shouldReceive('getEspecies')->withAnyArgs()->once()->andReturn($especiesEsperadas);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+	 
+	    // Invocar al index de especiesControllers
+	    $respuestaActual = $this->call('GET', 'api/especies');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => false,
+			'especies' => $especiesEsperadas -> toArray()),
+			200
+		);
+
+	    // Comparar que contenido y código sean iguales
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+}

--- a/Api/OMMFCM/app/tests/EspeciesControllerTest.php
+++ b/Api/OMMFCM/app/tests/EspeciesControllerTest.php
@@ -1,38 +1,17 @@
 <?php
 
-class EspeciesControllerTest extends TestCase {
-
-/*	public function setUp()
-	{
-	    parent::setUp();
-	 
-	    $this->mock('Services\ServicioOMMFCMInterface');
-	}
-	
-	public function tearDown()
-    {
-        Mockery::close();
-    } 
-	
-	public function mock($class)
-	{
-	    $mock = Mockery::mock($class);
-	 
-	    $this->app->instance($class, $mock);
-	 
-	    return $mock;
-	}
-	*/
+class EspeciesControllerTest extends TestCase 
+{
 	/**
-	 * A basic functional test example.
+	 * Prueba la ruta get api/especies enviando parámetros válidos.
 	 *
 	 * @return void
 	 */
-	public function testIndex()
+	public function testObtenerEspeciesConParametrosValidos()
 	{
 	   	// Generar especies que devuelve el servicio mock
 	   	$especiesEsperadas = new Especie();
-	   	$especiesEsperadas -> nombreComun = 'unNombreDePrueba';
+	   	$especiesEsperadas -> nombreComun = 'especieTest';
 
 	   	// Crear servicio mock
 		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
@@ -44,7 +23,7 @@ class EspeciesControllerTest extends TestCase {
 	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
 	 
 	    // Invocar al index de especiesControllers
-	    $respuestaActual = $this->call('GET', 'api/especies');
+	    $respuestaActual = $this->call('GET', 'api/especies', ['pagina' => '1', 'resultados' => '2']);
 
 	    // Generar respuesta esperada
 	    $respuestaEsperada = Response::json(array(
@@ -65,4 +44,568 @@ class EspeciesControllerTest extends TestCase {
             $respuestaActual);
 	}
 
+	/**
+	 * Prueba la ruta get api/especies enviando parámetros inválidos.
+	 *
+	 * @return void
+	 */
+	public function testObtenerEspeciesConParametrosInvalidos()
+	{
+	   	// Generar especies que devuelve el servicio mock
+	   	$especiesEsperadas = new Especie();
+
+	   	// Invocar al index de especiesControllers
+	    $respuestaActual = $this->call('GET', 'api/especies', ['pagina' => 'ABC', 'resultados' => '-2']);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			400
+		);
+
+	    // Comparar que contenido y código sean iguales
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta get api/especies enviando parámetros extras.
+	 *
+	 * @return void
+	 */
+	public function testObtenerEspeciesConParametrosExtras()
+	{
+	   	// Generar especies que devuelve el servicio mock
+	   	$especiesEsperadas = new Especie();
+
+	   	// Invocar al index de especiesControllers
+	    $respuestaActual = $this->call('GET', 'api/especies', ['pagina' => 'ABC', 'resultados' => '-2', 'parametroExtra' => 'extra']);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			404
+		);
+
+	    // Comparar que contenido y código sean iguales
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta get api/especies sin enviar parámetros.
+	 *
+	 * @return void
+	 */
+	public function testObtenerEspeciesSinParametros()
+	{
+	   	// Generar especies que devuelve el servicio mock
+	   	$especiesEsperadas = new Especie();
+
+	    // Invocar al index de especiesControllers
+	    $respuestaActual = $this->call('GET', 'api/especies');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			404
+		);
+
+	    // Comparar que contenido y código sean iguales
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		 $this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta post api/especies con parámetros válidos 
+	 * @return [type] [description]
+	 */
+	public function testCrearEspecieConParametrosValidos()
+	{	 
+	   	// codigo que regresa el mock
+	   	$codigoEsperado = 201;
+
+		// obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosValidos.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+ 
+		// Generar Especie que devuelve la ruta
+ 	   	$especieEsperada = new Especie();
+	   	$especieEsperada -> nombreComun = $datos['nombreComun'];
+	   	$especieEsperada -> nombreCientifico = $datos['nombreCientifico'];
+	   	$especieEsperada -> idEstadoEspecie = $datos['idEstadoEspecie'];
+	   	$especieEsperada -> idEstadoEspecie2 = $datos['idEstadoEspecie2'];
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo crearEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('crearEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+	 
+	    // Invocar al store de especies
+	    $respuestaActual = $this->call('POST', 'api/especies', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => false,
+			'especie' => $especieEsperada),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta post api/especies con parámetros invalidos 
+	 * @return [type] [description]
+	 */
+	public function testCrearEspecieConParametrosInvalidos()
+	{	 
+		// Generar el código que devuelve el servicio mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo crearEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('crearEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosInvalidos.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+
+	   	// Invocar al store de especies
+	    $respuestaActual = $this->call('POST', 'api/especies', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta post api/especies sin enviar parámetros
+	 * @return [type] [description]
+	 */
+	public function testCrearEspecieSinParametros()
+	{	 
+		// Generar código que devuelve el mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo crearEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('crearEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Invocar al store de especies
+	    $respuestaActual = $this->call('POST', 'api/especies');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta post api/especies con parámetros extras 
+	 * @return [type] [description]
+	 */
+	public function testCrearEspecieConParametrosExtras()
+	{	 
+		// Generar código que devuelve el servicio mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo crearEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('crearEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosExtras.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+	    
+	    // Invocar al store de especies
+	    $respuestaActual = $this->call('POST', 'api/especies', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta put api/especies con parámetros válidos 
+	 * @return [type] [description]
+	 */
+	public function testModificarEspecieConParametrosValidos()
+	{	 
+	   	// codigo que regresa el mock
+	   	$codigoEsperado = 200;
+
+		// obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosValidos.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+ 
+		// Generar Especie que devuelve la ruta
+ 	   	$especieEsperada = new Especie();
+	   	$especieEsperada -> nombreComun = $datos['nombreComun'];
+	   	$especieEsperada -> nombreCientifico = $datos['nombreCientifico'];
+	   	$especieEsperada -> idEstadoEspecie = $datos['idEstadoEspecie'];
+	   	$especieEsperada -> idEstadoEspecie2 = $datos['idEstadoEspecie2'];
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo modificarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('modificarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+	 
+	    // Invocar al update de especies
+	    $respuestaActual = $this->call('PUT', 'api/especies/1', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => false,
+			'especie' => $especieEsperada),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta put api/especies con parámetros invalidos 
+	 * @return [type] [description]
+	 */
+	public function testModificarEspecieConParametrosInvalidos()
+	{	 
+		// Generar el código que devuelve el servicio mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo modificarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('modificarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosInvalidos.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+
+	   	// Invocar al update de especies
+	    $respuestaActual = $this->call('PUT', 'api/especies/1', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta put api/especies sin enviar parámetros
+	 * @return [type] [description]
+	 */
+	public function testModificarEspecieSinParametros()
+	{	 
+		// Generar código que devuelve el mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo modificarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('modificarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Invocar al update de especies
+	    $respuestaActual = $this->call('PUT', 'api/especies/1');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta put api/especies con parámetros extras 
+	 * @return [type] [description]
+	 */
+	public function testModificarEspecieConParametrosExtras()
+	{	 
+		// Generar el código que devuelve el servicio mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo modificarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('modificarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Obtener los parámetros de la consulta
+        $archivoJson = __DIR__ . '/jsons/especieConParametrosExtras.json';
+	   	$datos = json_decode(file_get_contents($archivoJson), true);
+
+	   	// Invocar al update de especies
+	    $respuestaActual = $this->call('PUT', 'api/especies/1', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta delete api/especies con parámetros validos 
+	 * @return [type] [description]
+	 */
+	public function testEliminarEspecie()
+	{	 
+		// Generar código que devuelve el mock
+	   	$codigoEsperado = 204;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo eliminarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('eliminarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Invocar al delete de especies
+	    $respuestaActual = $this->call('DELETE', 'api/especies/1');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => false),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta delete api/especies con parámetros extras 
+	 * @return [type] [description]
+	 */
+	public function testEliminarEspecieConParametrosExtras()
+	{	 
+		// Generar código que devuelve el mock
+	   	$codigoEsperado = 400;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo eliminarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('eliminarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Generar parámetros de la consulta
+	 	$datos['nombreCientifico'] = 'Prueba';
+
+	    // Invocar al delete de especies
+	    $respuestaActual = $this->call('DELETE', 'api/especies/1', $datos);
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
+
+	/**
+	 * Prueba la ruta delete api/especies con una especie que no existe simulando un error interno 
+	 * @return [type] [description]
+	 */
+	public function testEliminarEspecieError()
+	{	 
+		// Generar código que devuelve el mock
+	   	$codigoEsperado = 404;
+
+	   	// Crear servicio mock
+		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
+
+		// Mockear la llamada a metodo eliminarEspecie para obtener el codigo esperado
+	    $mock->shouldReceive('eliminarEspecie')->withAnyArgs()->once()->andReturn($codigoEsperado);
+	 
+	 	// Inyectar servicio mock
+	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
+
+	    // Invocar al delete de especies
+	    $respuestaActual = $this->call('DELETE', 'api/especies/-1');
+
+	    // Generar respuesta esperada
+	    $respuestaEsperada = Response::json(array(
+			'error' => true),
+			$codigoEsperado
+		);
+
+	    // Comparar que contenido y código sean iguales
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'data'),  /* valor esperado */
+            'data',  /* nombre del atributo */
+            $respuestaActual); /* objeto actual */
+
+		$this->assertAttributeEquals(
+            PHPUnit_Framework_Assert::readAttribute($respuestaEsperada, 'statusCode'), 
+            'statusCode',
+            $respuestaActual);
+	}
 }

--- a/Api/OMMFCM/app/tests/IncidentesControllerTest.php
+++ b/Api/OMMFCM/app/tests/IncidentesControllerTest.php
@@ -93,16 +93,7 @@ class IncidentesControllerTest extends TestCase {
 		// Generar Incidente que devuelve el servicio mock
 	    $incidentesEsperados = new Incidente();
 
-	   	// Crear servicio mock
-		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
-
-		// Mockear la llamada a metodo getIncidentes/getIncidentesPorEspecie para que devuelva los incidentes esperados
-	    $mock->shouldReceive('getIncidentes','getIncidentesPorEspecie')->withAnyArgs()->once()->andReturn($incidentesEsperados);
-		
-	 	// Inyectar servicio mock
-	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
-
-	    // Invocar al index de incidentesController
+	   	// Invocar al index de incidentesController
 	    $respuestaActual = $this->call('GET', 'api/incidentes', ['pagina' => 'ABC', 'resultados' => '-45', 'idEspecie' => 'Perro']);
 
 	    // Generar respuesta esperada
@@ -132,16 +123,7 @@ class IncidentesControllerTest extends TestCase {
 		// Generar Incidente que devuelve el servicio mock
 	    $incidentesEsperados = new Incidente();
 
-	   	// Crear servicio mock
-		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
-
-		// Mockear la llamada a metodo getIncidentes/getIncidentesPorEspecie para que devuelva los incidentes esperados
-	    $mock->shouldReceive('getIncidentes', 'getIncidentesPorEspecie')->withAnyArgs()->once()->andReturn($incidentesEsperados);
-	 
-	 	// Inyectar servicio mock
-	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
-
-	    // Invocar al index de incidentesController
+	   	// Invocar al index de incidentesController
 	    $respuestaActual = $this->call('GET', 'api/incidentes',['carretera' => 'guanajuato', 'pagina' => 'ABC', 'resultados' => '-45', 'idEspecie' => 'Perro']);
 
 	    // Generar respuesta esperada
@@ -171,16 +153,7 @@ class IncidentesControllerTest extends TestCase {
 		// Generar Incidente que devuelve el servicio mock
 	    $incidentesEsperados = new Incidente();
 
-	   	// Crear servicio mock
-		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
-
-		// Mockear la llamada a metodo getIncidentes/getIncidentesPorEspecie para que devuelva los incidentes esperados
-	    $mock->shouldReceive('getIncidentes', 'getIncidentesPorEspecie')->withAnyArgs()->once()->andReturn($incidentesEsperados);
-	 
-	 	// Inyectar servicio mock
-	    $this->app->instance('Services\ServicioOMMFCMInterface', $mock);
-
-	    // Invocar al index de incidentesController
+	   	// Invocar al index de incidentesController
 	    $respuestaActual = $this->call('GET', 'api/incidentes');
 
 	    // Generar respuesta esperada
@@ -208,7 +181,7 @@ class IncidentesControllerTest extends TestCase {
 	public function testCrearIncidenteConParametrosValidos()
 	{	 
 		// codigo que regresa el mock
-	   	$codigoEsperado = 200;
+	   	$codigoEsperado = 201;
 
 	   	// obtener los parámetros de la consulta
         $archivoJson = __DIR__ . '/jsons/crearIncidenteParametrosValidos.json';
@@ -346,7 +319,7 @@ class IncidentesControllerTest extends TestCase {
 	public function testCrearIncidenteConParametrosExtras()
 	{	 
 		// Generar código que devuelve el servicio mock
-	   	$codigoEsperado = 404;
+	   	$codigoEsperado = 400;
 
 	   	// Crear servicio mock
 		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
@@ -476,7 +449,7 @@ class IncidentesControllerTest extends TestCase {
 	public function testModificarIncidenteSinParametros()
 	{	 
 		// Generar código que devuelve el mock
-	   	$codigoEsperado = 404;
+	   	$codigoEsperado = 400;
 
 	   	// Crear servicio mock
 		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
@@ -515,7 +488,7 @@ class IncidentesControllerTest extends TestCase {
 	public function testModificarIncidenteConParametrosExtras()
 	{	 
 		// Generar código que devuelve el mock e incidente esperado
-	   	$codigoEsperado = 404;
+	   	$codigoEsperado = 400;
 
 	   	// Crear servicio mock
 		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
@@ -552,7 +525,7 @@ class IncidentesControllerTest extends TestCase {
 	}
 
 	/**
-	 * Prueba la ruta delete api/incidentes con Parámetros extras 
+	 * Prueba la ruta delete api/incidentes con parámetros validos 
 	 * @return [type] [description]
 	 */
 	public function testEliminarIncidente()
@@ -597,7 +570,7 @@ class IncidentesControllerTest extends TestCase {
 	public function testEliminarIncidenteConParametrosExtras()
 	{	 
 		// Generar código que devuelve el mock e incidente esperado
-	   	$codigoEsperado = 404;
+	   	$codigoEsperado = 400;
 
 	   	// Crear servicio mock
 		$mock = Mockery::mock('Services\ServicioOMMFCMInterface');
@@ -617,7 +590,7 @@ class IncidentesControllerTest extends TestCase {
 
 	    // Generar respuesta esperada
 	    $respuestaEsperada = Response::json(array(
-			'error' => false),
+			'error' => true),
 			$codigoEsperado
 		);
 
@@ -634,10 +607,10 @@ class IncidentesControllerTest extends TestCase {
 	}
 
 	/**
-	 * Prueba la ruta delete api/incidentes con un incidente que no existe 
+	 * Prueba la ruta delete api/incidentes con un incidente que no existe simulando un error interno 
 	 * @return [type] [description]
 	 */
-	public function testEliminarIncidenteConIdInexistente()
+	public function testEliminarIncidenteError()
 	{	 
 		// Generar código que devuelve el mock e incidente esperado
 	   	$codigoEsperado = 404;
@@ -656,7 +629,7 @@ class IncidentesControllerTest extends TestCase {
 
 	    // Generar respuesta esperada
 	    $respuestaEsperada = Response::json(array(
-			'error' => false),
+			'error' => true),
 			$codigoEsperado
 		);
 

--- a/Api/OMMFCM/app/tests/jsons/especieConParametrosExtras.json
+++ b/Api/OMMFCM/app/tests/jsons/especieConParametrosExtras.json
@@ -1,0 +1,7 @@
+{
+   "nombreComun" : "Oso americano",
+   "nombreCientifico" : "Ursus americanus",
+   "idEstadoEspecie" : "14",
+   "idEstadoEspecie2" : "10",
+   "parametroExtra" : "parametroExtra"
+}

--- a/Api/OMMFCM/app/tests/jsons/especieConParametrosInvalidos.json
+++ b/Api/OMMFCM/app/tests/jsons/especieConParametrosInvalidos.json
@@ -1,0 +1,6 @@
+{
+   "nombreComun" : "2",
+   "nombreCientifico" : "Ursus americanus",
+   "idEstadoEspecie" : "estado1",
+   "idEstadoEspecie2" : "10"
+}

--- a/Api/OMMFCM/app/tests/jsons/especieConParametrosValidos.json
+++ b/Api/OMMFCM/app/tests/jsons/especieConParametrosValidos.json
@@ -1,0 +1,6 @@
+{
+   "nombreComun" : "Oso americano",
+   "nombreCientifico" : "Ursus americanus",
+   "idEstadoEspecie" : "14",
+   "idEstadoEspecie2" : "10"
+}


### PR DESCRIPTION
Se añadieron pruebas de controlador especies y se ajustaron codigos de estado en pruebas de incidentes, así como comportamiento en gets fallidos.
