### PR TITLE
Obtener incidentes para reportes

### DIFF
--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -23,7 +23,21 @@ class IncidentesController extends \BaseController
 
 	   	if(is_null($idEspecie))	
 		{
-			$incidentes = $this->servicioOMMFCM->getIncidentes($pagina, $resultados);
+			if(is_null($pagina))
+			{
+				// El método getIncidentes regresa un array, mientras que los otros métodos regresan una colección. Por eso se debe tratar diferente
+				$incidentes = $this->servicioOMMFCM->getIncidentes();
+				
+				return Response::json(array(
+					'error' => false,
+					'incidentes' => $incidentes),
+					200
+				);				
+			}
+			else
+			{
+				$incidentes = $this->servicioOMMFCM->getIncidentesPaginados($pagina, $resultados);							
+			}
 		}
 		else
 		{

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -8,10 +8,23 @@
 	use Estado;
 	use EstadoEspecie;
 	use EstadoEspecie2;
-	
+	use DB;
+
 	class ServicioOMMFCM implements ServicioOMMFCMInterface{
 		
-		public function getIncidentes($pagina, $resultados)
+		public function getIncidentes()
+		{
+			// Debido a la concatenación de los estados especies a la consulta, se dificultó usar los modelos de Eloquent
+			$incidentes = DB::table('incidentes')
+						->join('especies', 'especies.idEspecie', '=', 'incidentes.idEspecie')
+						->join('estadosEspecies', 'estadosEspecies.idEstadoEspecie', '=', 'especies.idEstadoEspecie')
+						->join('estadosEspecies2', 'estadosEspecies2.idEstadoEspecie2', '=', 'especies.idEstadoEspecie2')
+						->get(array('fecha', 'km', 'ruta', 'lat', 'long', 'estadosEspecies.estado', 'estadosEspecies2.estado AS estado2', 'nombreCientifico', 'nombreComun'));
+
+			return $incidentes;
+		}
+
+		public function getIncidentesPaginados($pagina, $resultados)
 		{
 	   		Incidente::resolveConnection()->getPaginator()->setCurrentPage($pagina);
 	   		$incidentes = Incidente::paginate($resultados);

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -19,7 +19,7 @@
 						->join('especies', 'especies.idEspecie', '=', 'incidentes.idEspecie')
 						->join('estadosEspecies', 'estadosEspecies.idEstadoEspecie', '=', 'especies.idEstadoEspecie')
 						->join('estadosEspecies2', 'estadosEspecies2.idEstadoEspecie2', '=', 'especies.idEstadoEspecie2')
-						->get(array('fecha', 'km', 'ruta', 'lat', 'long', 'estadosEspecies.estado', 'estadosEspecies2.estado AS estado2', 'nombreCientifico', 'nombreComun'));
+						->get(array('fecha', 'km', 'ruta', 'lat', 'long', 'nombreCientifico', 'nombreComun', 'estadosEspecies.estado', 'estadosEspecies2.estado AS estado2'));
 
 			return $incidentes;
 		}

--- a/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
@@ -2,7 +2,8 @@
 	namespace services;
 
 	interface ServicioOMMFCMInterface {  
-	    public function getIncidentes($pagina, $resultados);
+	    public function getIncidentes();
+	    public function getIncidentesPaginados($pagina, $resultados);
 	    public function getIncidentesPorEspecie($idEspecie, $pagina, $resultados); 
 	    public function crearIncidente($incidente, $imagen64, $extensionImg);
 	    public function eliminarIncidente($id);


### PR DESCRIPTION
Se agregó el método getIncidentes, el cual regresa todos los incidentes
con su especie y a su vez dichas especies con sus estados. Para
consultar la ruta simplemente hacer un /api/incidentes sin parámetros
