### PR TITLE
Correción

### DIFF
--- a/Api/OMMFCM/app/controllers/IncidentesController.php
+++ b/Api/OMMFCM/app/controllers/IncidentesController.php
@@ -20,13 +20,14 @@ class IncidentesController extends \BaseController
 		$pagina = Request::get('pagina');
 	   	$resultados = Request::get('resultados');
 	   	$idEspecie = Request::get('idEspecie');
+	   	$reporte = Request::get('reporte');
 
 	   	if(is_null($idEspecie))	
 		{
 			if(is_null($pagina))
 			{
-				// El método getIncidentes regresa un array, mientras que los otros métodos regresan una colección. Por eso se debe tratar diferente
-				$incidentes = $this->servicioOMMFCM->getIncidentes();
+				// El método getIncidentesPorReporte regresa un array, mientras que los otros métodos regresan una colección. Por eso se debe tratar diferente
+				$incidentes = $this->servicioOMMFCM->getIncidentesPorReporte($reporte);
 				
 				return Response::json(array(
 					'error' => false,

--- a/Api/OMMFCM/app/services/ServicioOMMFCM.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCM.php
@@ -12,14 +12,27 @@
 
 	class ServicioOMMFCM implements ServicioOMMFCMInterface{
 		
-		public function getIncidentes()
+		public function getIncidentesPorReporte($reporte)
 		{
-			// Debido a la concatenación de los estados especies a la consulta, se dificultó usar los modelos de Eloquent
+			$columnas;
+			if($reporte == 1)
+			{
+				// columnas especiales para el excel
+				$columnas = array('fecha', 'ruta', 'km','nombreCientifico', 'nombreComun', 'estadosEspecies.estado', 'estadosEspecies2.estado AS estado2');
+			}
+			
+			if($reporte == 2)
+			{
+				// columnas especiales para el mapa
+				$columnas = array('fecha', 'lat', 'long', 'especies.idEspecie','nombreCientifico', 'nombreComun');
+			}
+
+			// obtener incidentes
 			$incidentes = DB::table('incidentes')
 						->join('especies', 'especies.idEspecie', '=', 'incidentes.idEspecie')
 						->join('estadosEspecies', 'estadosEspecies.idEstadoEspecie', '=', 'especies.idEstadoEspecie')
 						->join('estadosEspecies2', 'estadosEspecies2.idEstadoEspecie2', '=', 'especies.idEstadoEspecie2')
-						->get(array('fecha', 'km', 'ruta', 'lat', 'long', 'nombreCientifico', 'nombreComun', 'estadosEspecies.estado', 'estadosEspecies2.estado AS estado2'));
+						->get($columnas);				
 
 			return $incidentes;
 		}
@@ -236,14 +249,14 @@
 
 	   	public function getEstadosEspecies()
 	   	{
-	   		$estadosEspecies = EstadoEspecie::all();
+	   		$estadosEspecies = EstadoEspecie::where('idEstadoEspecie', '>', '0')->get();
 
 	   		return $estadosEspecies;
 	   	}
 
 	   	public function getEstadosEspecies2()
 	   	{
-	   		$estadosEspecies2 = EstadoEspecie2::all();
+	   		$estadosEspecies2 = EstadoEspecie2::where('idEstadoEspecie2', '>', '0')->get();
 
 	   		return $estadosEspecies2;
 	   	}

--- a/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
+++ b/Api/OMMFCM/app/services/ServicioOMMFCMInterface.php
@@ -2,7 +2,7 @@
 	namespace services;
 
 	interface ServicioOMMFCMInterface {  
-	    public function getIncidentes();
+	    public function getIncidentesPorReporte($reporte);
 	    public function getIncidentesPaginados($pagina, $resultados);
 	    public function getIncidentesPorEspecie($idEspecie, $pagina, $resultados); 
 	    public function crearIncidente($incidente, $imagen64, $extensionImg);


### PR DESCRIPTION
Había un defecto al obtener los incidentes para los reportes, pues no
regresaba los que tuvieran estados nulos. Se agregó un parámetro en la
ruta para definir si los incidentes son para el excel o para el mapa,
además de que se modificó la ruta estadosEspecies para que no regrese
el estado 0
